### PR TITLE
Fix syntax error about initialState

### DIFF
--- a/src/flumpt.js
+++ b/src/flumpt.js
@@ -43,7 +43,7 @@ export function createRenderer({emitter, render}) {
 export class Flux extends EventEmitter {
   constructor({renderer, initialState}) {
     super();
-    this.state = initialState ? {};
+    this.state = initialState ? initialState : {};
     this._renderer = createRenderer({emitter: this, render: renderer});
     this._renderedElement = null;
     this.subscribe();


### PR DESCRIPTION
`this.state = initialState ? {};` is invalid syntax.
This pull request fix this.

``` js
this.state = initialState ? initialState : {};
```

:memo: with more precision:

``` js
this.state = initialState !== undefined  ? initialState : {};
// is equal to ES6 default parameter 
```
