### PR TITLE
Add entry point function to Flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ app.on(":end-anync-updating", () => {
   // hide ui lock
 });
 
-app.update(_initialState => ({count: 1})) // it fires rendering
+app.start(); // it fires rendering
 ```
 
 - `Flux` is `EventEmitter`

--- a/src/flumpt.js
+++ b/src/flumpt.js
@@ -154,6 +154,10 @@ export class Flux extends EventEmitter {
   subscribe() {
     // override me
   }
+
+  start() {
+    this._finishUpdate(this.state);
+  }
 }
 
 export class Incubator extends Provider {


### PR DESCRIPTION
While we can specify `initialState` in Flux's constructor, currently it requires to call `update` with some function to fire rendering. But the function's result is also a initial state and I felt it's redundant.

So I propose to add a function to fire rendering without `nextStateFn`.
